### PR TITLE
feat: adds superset docker services and open edx integrations

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -6,14 +6,24 @@ Installation
 
 ::
 
-    pip install git+https://github.com/opencraft/tutor-contrib-superset
+    pip install git+https://github.com/open-craft/tutor-contrib-superset
 
 Usage
 -----
 
 ::
 
+    # Enable this plugin
     tutor plugins enable superset
+    tutor config save
+
+    # Set up SSO with Open edX
+    tutor [dev|local] do init --limit superset
+
+
+Connect to Superset's UI on the configured port (default is `:8088`):
+
+  http://local.overhang.io:8088
 
 
 License

--- a/tutorsuperset/plugin.py
+++ b/tutorsuperset/plugin.py
@@ -17,6 +17,26 @@ hooks.Filters.CONFIG_DEFAULTS.add_items(
         # Each new setting is a pair: (setting_name, default_value).
         # Prefix your setting names with 'SUPERSET_'.
         ("SUPERSET_VERSION", __version__),
+        ("SUPERSET_TAG", "latest-dev"),
+        ("SUPERSET_HOST", "{{ LMS_HOST }}"),
+        ("SUPERSET_PORT", "8088"),
+        # TODO: use our mysql database instead?
+        ("SUPERSET_DB_DIALECT", "postgresql"),
+        ("SUPERSET_DB_HOST", "superset_db"),
+        ("SUPERSET_DB_PORT", "5432"),
+        ("SUPERSET_DB_NAME", "superset"),
+        ("SUPERSET_DB_USERNAME", "superset"),
+        ("SUPERSET_OAUTH2_BASE_URL", "{% if ENABLE_HTTPS %}https{% else %}http{% endif %}://{{ LMS_HOST }}:8000"),
+        ("SUPERSET_OAUTH2_ACCESS_TOKEN_URL", "{{ SUPERSET_OAUTH2_BASE_URL }}/oauth2/access_token/"),
+        ("SUPERSET_OAUTH2_AUTHORIZE_URL", "{{ SUPERSET_OAUTH2_BASE_URL }}/oauth2/authorize/"),
+        ("SUPERSET_OPENEDX_USERNAME_URL", "{{ SUPERSET_OAUTH2_BASE_URL }}/api/user/v1/me"),
+        ("SUPERSET_OPENEDX_USER_PROFILE_URL", "{{ SUPERSET_OAUTH2_BASE_URL }}/api/user/v1/accounts/{username}"),
+        ("SUPERSET_OPENEDX_COURSES_LIST_URL",
+         "{{ SUPERSET_OAUTH2_BASE_URL }}/api/courses/v1/courses/?permissions={permission}&username={username}"),
+        # This admin account is unusable when SSO is enabled,
+        # but it's used by the "load examples" optional script.
+        ("SUPERSET_ADMIN_USERNAME", "admin"),
+        ("SUPERSET_LOAD_EXAMPLES", 0),
     ]
 )
 
@@ -27,7 +47,11 @@ hooks.Filters.CONFIG_UNIQUE.add_items(
         # Each new setting is a pair: (setting_name, unique_generated_value).
         # Prefix your setting names with 'SUPERSET_'.
         # For example:
-        # ("SUPERSET_SECRET_KEY", "{{ 24|random_string }}"),
+        ("SUPERSET_SECRET_KEY", "{{ 24|random_string }}"),
+        ("SUPERSET_DB_PASSWORD", "{{ 24|random_string }}"),
+        ("SUPERSET_OAUTH2_CLIENT_ID", "{{ 16|random_string }}"),
+        ("SUPERSET_OAUTH2_CLIENT_SECRET", "{{ 16|random_string }}"),
+        ("SUPERSET_ADMIN_PASSWORD", "{{ 10|random_string }}"),
     ]
 )
 
@@ -45,11 +69,29 @@ hooks.Filters.CONFIG_OVERRIDES.add_items(
 # INITIALIZATION TASKS
 ########################################
 
-# To run the script from templates/superset/tasks/myservice/init, add:
-# hooks.Filters.COMMANDS_INIT.add_item((
-#     "myservice",
-#     ("superset", "tasks", "myservice", "init"),
-# ))
+# To add a custom initialization task, create a bash script template under:
+# tutorsuperset/templates/superset/jobs/init/
+# and then add it to the MY_INIT_TASKS list. Each task is in the format:
+# ("<service>", ("<path>", "<to>", "<script>", "<template>"))
+MY_INIT_TASKS = [
+    # For example, to add LMS initialization steps, you could add the script template at:
+    # tutorsuperset/templates/superset/jobs/init/lms.sh
+    # And then add the line:
+    ### ("lms", ("superset", "jobs", "init", "lms.sh")),
+    ("superset", ("superset", "jobs", "init", "init-superset.sh")),
+    ("lms", ("superset", "jobs", "init", "init-openedx.sh")),
+]
+
+# For each task added to MY_INIT_TASKS, we load the task template
+# and add it to the CLI_DO_INIT_TASKS filter, which tells Tutor to
+# run it as part of the `init` job.
+for service, template_path in MY_INIT_TASKS:
+    full_path: str = pkg_resources.resource_filename(
+        "tutorsuperset", os.path.join("templates", *template_path)
+    )
+    with open(full_path, encoding="utf-8") as init_task_file:
+        init_task: str = init_task_file.read()
+    hooks.Filters.CLI_DO_INIT_TASKS.add_item((service, init_task))
 
 
 ########################################
@@ -98,6 +140,119 @@ hooks.Filters.ENV_TEMPLATE_TARGETS.add_items(
         ("superset/build", "plugins"),
         ("superset/apps", "plugins"),
     ],
+)
+
+# docker-compose statements shared between the superset services
+SUPERSET_DOCKER_COMPOSE_SHARED = """image: apache/superset:{{ SUPERSET_TAG }}
+  environment:
+    DATABASE_DIALECT: {{ SUPERSET_DB_DIALECT }}
+    DATABASE_HOST: {{ SUPERSET_DB_HOST }}
+    DATABASE_PORT: {{ SUPERSET_DB_PORT }}
+    DATABASE_DB: {{ SUPERSET_DB_NAME }}
+    DATABASE_HOST: {{ SUPERSET_DB_HOST }}
+    DATABASE_PASSWORD: {{ SUPERSET_DB_PASSWORD }}
+    DATABASE_USER: {{ SUPERSET_DB_USERNAME }}
+    OPENEDX_MYSQL_HOST: {{ MYSQL_HOST }}
+    OPENEDX_MYSQL_PORT: {{ MYSQL_PORT }}
+    OPENEDX_MYSQL_DATABASE: {{ OPENEDX_MYSQL_DATABASE }}
+    OPENEDX_MYSQL_USERNAME: {{ OPENEDX_MYSQL_USERNAME }}
+    OPENEDX_MYSQL_PASSWORD: {{ OPENEDX_MYSQL_PASSWORD }}
+    OAUTH2_CLIENT_ID: {{ SUPERSET_OAUTH2_CLIENT_ID }}
+    OAUTH2_CLIENT_SECRET: {{ SUPERSET_OAUTH2_CLIENT_SECRET }}
+    OAUTH2_BASE_URL: {{ SUPERSET_OAUTH2_BASE_URL }}
+    OAUTH2_ACCESS_TOKEN_URL: {{ SUPERSET_OAUTH2_ACCESS_TOKEN_URL }}
+    OAUTH2_AUTHORIZE_URL: {{ SUPERSET_OAUTH2_AUTHORIZE_URL }}
+    OPENEDX_USERNAME_URL: {{ SUPERSET_OPENEDX_USERNAME_URL }}
+    OPENEDX_USER_PROFILE_URL: {{ SUPERSET_OPENEDX_USER_PROFILE_URL }}
+    OPENEDX_COURSES_LIST_URL: {{ SUPERSET_OPENEDX_COURSES_LIST_URL }}
+    SECRET_KEY: {{ SUPERSET_SECRET_KEY }}
+    PYTHONPATH: /app/pythonpath:/app/docker/pythonpath_dev
+    REDIS_HOST: superset_cache
+    REDIS_PORT: 6379
+    FLASK_ENV: production
+    SUPERSET_ENV: production
+    SUPERSET_LOAD_EXAMPLES: {{ SUPERSET_LOAD_EXAMPLES }}
+    SUPERSET_PORT: {{ SUPERSET_PORT }}
+    ADMIN_USERNAME: {{ SUPERSET_ADMIN_USERNAME }}
+    ADMIN_PASSWORD: {{ SUPERSET_ADMIN_PASSWORD }}
+    CYPRESS_CONFIG: 0
+  user: root
+  depends_on:
+    - superset-db
+    - superset-cache
+  volumes:
+    - ../../env/plugins/superset/apps/docker:/app/docker
+    - ../../env/plugins/superset/apps/pythonpath:/app/pythonpath
+    - ../../env/plugins/superset/apps/superset_home:/app/superset_home
+  restart: unless-stopped"""
+
+# Modified from https://github.com/apache/superset/blob/969c963/docker-compose-non-dev.yml
+hooks.Filters.ENV_PATCHES.add_item(
+    (
+        "local-docker-compose-services",
+        f"""
+superset-cache:
+  image: redis:latest
+  container_name: superset_cache
+  restart: unless-stopped
+  volumes:
+    - ../../data/superset/redis:/data
+
+superset-db:
+  environment:
+    POSTGRES_DB: {{{{ SUPERSET_DB_NAME }}}}
+    POSTGRES_USER: {{{{ SUPERSET_DB_USERNAME }}}}
+    POSTGRES_PASSWORD: {{{{ SUPERSET_DB_PASSWORD }}}}
+  image: postgres:10
+  container_name: superset_db
+  restart: unless-stopped
+  volumes:
+    - ../../data/superset/postgresql:/var/lib/postgresql/data
+
+superset-app:
+  {SUPERSET_DOCKER_COMPOSE_SHARED}
+  container_name: superset_app
+  command: ["bash", "/app/docker/docker-bootstrap.sh", "app-gunicorn"]
+  ports:
+    - 8088:{{{{ SUPERSET_PORT }}}}
+
+superset-worker:
+  {SUPERSET_DOCKER_COMPOSE_SHARED}
+  container_name: superset_worker
+  command: ["bash", "/app/docker/docker-bootstrap.sh", "worker"]
+  healthcheck:
+    test: ["CMD-SHELL", "celery inspect ping -A superset.tasks.celery_app:app -d celery@$$HOSTNAME"]
+
+superset-worker-beat:
+  {SUPERSET_DOCKER_COMPOSE_SHARED}
+  container_name: superset_worker_beat
+  command: ["bash", "/app/docker/docker-bootstrap.sh", "worker"]
+  healthcheck:
+    disable: true
+
+# All the superset services we need to run together
+superset:
+  {SUPERSET_DOCKER_COMPOSE_SHARED}
+  command: ["bash"]
+  depends_on:
+    - superset-app
+    - superset-worker
+    - superset-worker-beat
+        """
+    )
+)
+
+# Initialization jobs
+hooks.Filters.ENV_PATCHES.add_item(
+    (
+        "local-docker-compose-jobs-services",
+        f"""
+superset-job:
+  {SUPERSET_DOCKER_COMPOSE_SHARED}
+  depends_on:
+    - superset
+        """
+    )
 )
 
 

--- a/tutorsuperset/plugin.py
+++ b/tutorsuperset/plugin.py
@@ -17,7 +17,7 @@ hooks.Filters.CONFIG_DEFAULTS.add_items(
         # Each new setting is a pair: (setting_name, default_value).
         # Prefix your setting names with 'SUPERSET_'.
         ("SUPERSET_VERSION", __version__),
-        ("SUPERSET_TAG", "latest-dev"),
+        ("SUPERSET_TAG", "2.0.1"),
         ("SUPERSET_HOST", "{{ LMS_HOST }}"),
         ("SUPERSET_PORT", "8088"),
         # TODO: use our mysql database instead?
@@ -33,10 +33,6 @@ hooks.Filters.CONFIG_DEFAULTS.add_items(
         ("SUPERSET_OPENEDX_USER_PROFILE_URL", "{{ SUPERSET_OAUTH2_BASE_URL }}/api/user/v1/accounts/{username}"),
         ("SUPERSET_OPENEDX_COURSES_LIST_URL",
          "{{ SUPERSET_OAUTH2_BASE_URL }}/api/courses/v1/courses/?permissions={permission}&username={username}"),
-        # This admin account is unusable when SSO is enabled,
-        # but it's used by the "load examples" optional script.
-        ("SUPERSET_ADMIN_USERNAME", "admin"),
-        ("SUPERSET_LOAD_EXAMPLES", 0),
     ]
 )
 
@@ -51,7 +47,6 @@ hooks.Filters.CONFIG_UNIQUE.add_items(
         ("SUPERSET_DB_PASSWORD", "{{ 24|random_string }}"),
         ("SUPERSET_OAUTH2_CLIENT_ID", "{{ 16|random_string }}"),
         ("SUPERSET_OAUTH2_CLIENT_SECRET", "{{ 16|random_string }}"),
-        ("SUPERSET_ADMIN_PASSWORD", "{{ 10|random_string }}"),
     ]
 )
 
@@ -171,11 +166,7 @@ SUPERSET_DOCKER_COMPOSE_SHARED = """image: apache/superset:{{ SUPERSET_TAG }}
     REDIS_PORT: 6379
     FLASK_ENV: production
     SUPERSET_ENV: production
-    SUPERSET_LOAD_EXAMPLES: {{ SUPERSET_LOAD_EXAMPLES }}
     SUPERSET_PORT: {{ SUPERSET_PORT }}
-    ADMIN_USERNAME: {{ SUPERSET_ADMIN_USERNAME }}
-    ADMIN_PASSWORD: {{ SUPERSET_ADMIN_PASSWORD }}
-    CYPRESS_CONFIG: 0
   user: root
   depends_on:
     - superset-db

--- a/tutorsuperset/templates/superset/apps/docker/docker-bootstrap.sh
+++ b/tutorsuperset/templates/superset/apps/docker/docker-bootstrap.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# Copied from original:
+#
+# https://github.com/apache/superset/blob/969c963/docker/docker-bootstrap.sh
+
+set -eo pipefail
+
+REQUIREMENTS_LOCAL="/app/docker/requirements-local.txt"
+# If Cypress run – overwrite the password for admin and export env variables
+if [ "$CYPRESS_CONFIG" == "true" ]; then
+    export SUPERSET_CONFIG=tests.integration_tests.superset_test_config
+    export SUPERSET_TESTENV=true
+    export SUPERSET__SQLALCHEMY_DATABASE_URI=postgresql+psycopg2://superset:superset@db:5432/superset
+fi
+#
+# Make sure we have dev requirements installed
+#
+if [ -f "${REQUIREMENTS_LOCAL}" ]; then
+  echo "Installing local overrides at ${REQUIREMENTS_LOCAL}"
+  pip install -r "${REQUIREMENTS_LOCAL}"
+else
+  echo "Skipping local overrides"
+fi
+
+if [[ "${1}" == "worker" ]]; then
+  echo "Starting Celery worker..."
+  celery --app=superset.tasks.celery_app:app worker -Ofair -l INFO
+elif [[ "${1}" == "beat" ]]; then
+  echo "Starting Celery beat..."
+  celery --app=superset.tasks.celery_app:app beat --pidfile /tmp/celerybeat.pid -l INFO -s "${SUPERSET_HOME}"/celerybeat-schedule
+elif [[ "${1}" == "app" ]]; then
+  echo "Starting web app..."
+  flask run -p 8088 --with-threads --reload --debugger --host=0.0.0.0
+elif [[ "${1}" == "app-gunicorn" ]]; then
+  echo "Starting web app..."
+  /usr/bin/run-server.sh
+fi

--- a/tutorsuperset/templates/superset/apps/docker/requirements-local.txt
+++ b/tutorsuperset/templates/superset/apps/docker/requirements-local.txt
@@ -1,0 +1,2 @@
+authlib  # OAuth2
+mysqlclient

--- a/tutorsuperset/templates/superset/apps/pythonpath/openedx_sso_security_manager.py
+++ b/tutorsuperset/templates/superset/apps/pythonpath/openedx_sso_security_manager.py
@@ -17,7 +17,6 @@ class OpenEdxSsoSecurityManager(SupersetSecurityManager):
         """
         res = super().set_oauth_session(provider, oauth_response)
 
-        # TODO: better to save to a database
         if provider == "openedxsso":
             _set_oauth_token(oauth_response)
         return res
@@ -112,7 +111,7 @@ def can_view_courses(username, field_name='course_id'):
     courses = _get_courses(username)
     logging.debug(f"{username} is course staff on {courses}")
 
-    # FIXME: what happens when the list of courses grows beyond what the query will handle?
+    # TODO: what happens when the list of courses grows beyond what the query will handle?
     if courses:
         course_id_list = ", ".join(
             f'"{course_id}"' for course_id in courses

--- a/tutorsuperset/templates/superset/apps/pythonpath/openedx_sso_security_manager.py
+++ b/tutorsuperset/templates/superset/apps/pythonpath/openedx_sso_security_manager.py
@@ -1,0 +1,202 @@
+from collections import namedtuple
+import logging
+import MySQLdb
+
+from flask import current_app, session
+from superset.security import SupersetSecurityManager
+from superset.extensions import security_manager
+from superset.utils.core import get_username
+from superset.utils.memoized import memoized
+
+
+class OpenEdxSsoSecurityManager(SupersetSecurityManager):
+
+    def set_oauth_session(self, provider, oauth_response):
+        """
+        Store the oauth token in the session for later retrieval.
+        """
+        res = super().set_oauth_session(provider, oauth_response)
+
+        # TODO: better to save to a database
+        if provider == "openedxsso":
+            _set_oauth_token(oauth_response)
+        return res
+
+    def oauth_user_info(self, provider, response=None):
+        openedx_apis = current_app.config['OPENEDX_API_URLS']
+        if provider == 'openedxsso':
+            oauth_remote = self.appbuilder.sm.oauth_remotes[provider]
+            username_url = openedx_apis['get_username']
+            me = oauth_remote.get(username_url).json()
+            logging.debug(f"{username_url}: {me}")
+            username = me['username']
+
+            user_profile_url = openedx_apis['get_profile'].format(username=username)
+            user_profile = oauth_remote.get(user_profile_url).json()
+            logging.debug(f"{user_profile_url}: {user_profile}")
+
+            user_roles = _get_user_roles(username)
+            logging.debug(f"user_roles: {user_roles}")
+
+            return {
+                'name': user_profile['name'],
+                'email': user_profile['email'],
+                'id': user_profile['username'],
+                'username': user_profile['username'],
+                'first_name': '',
+                'last_name': '',
+                'role_keys': user_roles,
+            }
+
+
+def _set_oauth_token(token):
+    """
+    Stores the oauth token in the session.
+    """
+    # TODO: is it better to store this in the database?
+    session["oauth_token"] = token
+
+
+def _get_oauth_token():
+    """
+    Retrieves the oauth token from the session.
+
+    Returns an empty hash if there is no session.
+    """
+    # TODO: handle refreshing expired tokens?
+    return session.get("oauth_token", {})
+
+
+def _get_user_roles(username):
+    """
+    Returns the Superset roles that should be associated with the given user.
+    """
+    user_access = _fetch_user_access(username)
+    logging.debug(f"user access: {user_access}")
+
+    if user_access.is_superuser:
+        return ["admin", "alpha", "openedx"]
+    elif user_access.is_staff:
+        return ["alpha", "openedx"]
+    else:
+        # User has to have staff access to one or more courses to view any content here.
+        courses = _get_courses(username)
+        if courses:
+            return ["gamma", "openedx"]
+        return []
+
+
+ALL_COURSES = "1 = 1"
+NO_COURSES = "1 = 0"
+
+def can_view_courses(username, field_name='course_id'):
+    """
+    Returns SQL WHERE clause which restricts access to the courses the current user has staff access to.
+    """
+    user = security_manager.get_user_by_username(username)
+    if user:
+        user_roles = security_manager.get_user_roles(user)
+    else:
+        user_roles = []
+    logging.debug(f"can_view_courses: {username} roles: {user_roles}")
+
+    # Users with no roles don't get to see any courses
+    if not user_roles:
+        return NO_COURSES
+
+    # Superusers and global staff have access to all courses
+    if ("Admin" in user_roles) or ("Alpha" in user_roles):
+        return ALL_COURSES
+
+    # Everyone else only has access if they're staff on a course.
+    courses = _get_courses(username)
+    logging.debug(f"{username} is course staff on {courses}")
+
+    # FIXME: what happens when the list of courses grows beyond what the query will handle?
+    if courses:
+        course_id_list = ", ".join(
+            f'"{course_id}"' for course_id in courses
+        )
+        return f"{field_name} in ({course_id_list})"
+    else:
+        # If you're not course staff on any courses, you don't get to see any.
+        return NO_COURSES
+
+
+UserAccess = namedtuple(
+    "UserAccess", ["username", "is_superuser", "is_staff"]
+)
+
+
+def _fetch_user_access(username):
+    """
+    Fetches the given user's access details from the Open edX User database
+    (since Open edX doesn't have an API for this).
+    """
+    cxn = _connect_openedx_db()
+    cursor = cxn.cursor()
+
+    query = "SELECT is_staff, is_superuser FROM auth_user WHERE username=%s"
+    if cursor.execute(query, (username,)):
+        (is_staff, is_superuser) = cursor.fetchone()
+        user_access = UserAccess(
+            username=username,
+            is_superuser=is_superuser,
+            is_staff=is_staff,
+        )
+    else:
+        user_access = UserAccess(
+            username=username,
+            is_superuser=False,
+            is_staff=False,
+        )
+
+    cursor.close()
+    cxn.close()
+    return user_access
+
+
+def _connect_openedx_db():
+    """
+    Return an open connection to the Open edX MySQL database.
+    """
+    openedx_database = current_app.config['OPENEDX_DATABASE']
+    return MySQLdb.connect(**openedx_database)
+
+
+@memoized
+def _get_courses(username, permission="staff", next_url=None):
+    """
+    Returns the list of courses the current user has access to.
+    """
+    courses = []
+
+    provider = session.get("oauth_provider")
+    oauth_remote = security_manager.oauth_remotes.get(provider)
+    if not oauth_remote:
+        logging.error("No OAuth2 provider? expected openedx")
+        return courses
+
+    token = _get_oauth_token()
+    if not token:
+        logging.error("No access_token? expected one provided by openedx")
+        return courses
+
+    openedx_apis = current_app.config['OPENEDX_API_URLS']
+    courses_url = openedx_apis['get_courses'].format(username=username, permission=permission)
+    url = next_url or courses_url
+    response = oauth_remote.get(url, token=token).json()
+
+    for course in response.get('results', []):
+        course_id = course.get('course_id')
+        if course_id:
+            courses.append(course_id)
+
+    # Recurse to iterate over all the pages of results
+    if response.get("next"):
+        next_courses = _get_courses(username, permission=permission, next_url=response['next'])
+        for course_id in next_courses:
+            courses.append(course_id)
+
+    logging.debug(f"{username} has {permission} access to {courses}")
+    return courses

--- a/tutorsuperset/templates/superset/apps/pythonpath/superset_config.py
+++ b/tutorsuperset/templates/superset/apps/pythonpath/superset_config.py
@@ -33,6 +33,8 @@ from typing import Optional
 from cachelib.file import FileSystemCache
 from celery.schedules import crontab
 
+from superset.superset_typing import CacheConfig
+
 
 def get_env_variable(var_name: str, default: Optional[str] = None) -> str:
     """Get the environment variable or raise exception."""
@@ -82,6 +84,21 @@ CACHE_CONFIG = {
 }
 DATA_CACHE_CONFIG = CACHE_CONFIG
 
+# Cache for dashboard filter state
+FILTER_STATE_CACHE_CONFIG: CacheConfig = {
+    "CACHE_DEFAULT_TIMEOUT": int(timedelta(days=90).total_seconds()),
+    # should the timeout be reset when retrieving a cached value
+    "REFRESH_TIMEOUT_ON_RETRIEVAL": True,
+    **CACHE_CONFIG,
+}
+
+# Cache for explore form data state
+EXPLORE_FORM_DATA_CACHE_CONFIG: CacheConfig = {
+    "CACHE_DEFAULT_TIMEOUT": int(timedelta(days=7).total_seconds()),
+    # should the timeout be reset when retrieving a cached value
+    "REFRESH_TIMEOUT_ON_RETRIEVAL": True,
+    **CACHE_CONFIG,
+}
 
 class CeleryConfig(object):
     BROKER_URL = f"redis://{REDIS_HOST}:{REDIS_PORT}/{REDIS_CELERY_DB}"

--- a/tutorsuperset/templates/superset/apps/pythonpath/superset_config.py
+++ b/tutorsuperset/templates/superset/apps/pythonpath/superset_config.py
@@ -1,0 +1,125 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+# This file is included in the final Docker image and SHOULD be overridden when
+# deploying the image to prod. Settings configured here are intended for use in local
+# development environments. Also note that superset_config_docker.py is imported
+# as a final step as a means to override "defaults" configured here
+#
+"""
+Modified from original:
+
+https://github.com/apache/superset/blob/969c963/docker/pythonpath_dev/superset_config.py
+"""
+import os
+from datetime import timedelta
+from typing import Optional
+
+from cachelib.file import FileSystemCache
+from celery.schedules import crontab
+
+
+def get_env_variable(var_name: str, default: Optional[str] = None) -> str:
+    """Get the environment variable or raise exception."""
+    try:
+        return os.environ[var_name]
+    except KeyError:
+        if default is not None:
+            return default
+        else:
+            error_msg = "The environment variable {} was missing, abort...".format(
+                var_name
+            )
+            raise EnvironmentError(error_msg)
+
+
+DATABASE_DIALECT = get_env_variable("DATABASE_DIALECT")
+DATABASE_USER = get_env_variable("DATABASE_USER")
+DATABASE_PASSWORD = get_env_variable("DATABASE_PASSWORD")
+DATABASE_HOST = get_env_variable("DATABASE_HOST")
+DATABASE_PORT = get_env_variable("DATABASE_PORT")
+DATABASE_DB = get_env_variable("DATABASE_DB")
+
+# The SQLAlchemy connection string.
+SQLALCHEMY_DATABASE_URI = "%s://%s:%s@%s:%s/%s" % (
+    DATABASE_DIALECT,
+    DATABASE_USER,
+    DATABASE_PASSWORD,
+    DATABASE_HOST,
+    DATABASE_PORT,
+    DATABASE_DB,
+)
+
+REDIS_HOST = get_env_variable("REDIS_HOST")
+REDIS_PORT = get_env_variable("REDIS_PORT")
+REDIS_CELERY_DB = get_env_variable("REDIS_CELERY_DB", "0")
+REDIS_RESULTS_DB = get_env_variable("REDIS_RESULTS_DB", "1")
+
+RESULTS_BACKEND = FileSystemCache("/app/superset_home/sqllab")
+
+CACHE_CONFIG = {
+    "CACHE_TYPE": "redis",
+    "CACHE_DEFAULT_TIMEOUT": 300,
+    "CACHE_KEY_PREFIX": "superset_",
+    "CACHE_REDIS_HOST": REDIS_HOST,
+    "CACHE_REDIS_PORT": REDIS_PORT,
+    "CACHE_REDIS_DB": REDIS_RESULTS_DB,
+}
+DATA_CACHE_CONFIG = CACHE_CONFIG
+
+
+class CeleryConfig(object):
+    BROKER_URL = f"redis://{REDIS_HOST}:{REDIS_PORT}/{REDIS_CELERY_DB}"
+    CELERY_IMPORTS = ("superset.sql_lab",)
+    CELERY_RESULT_BACKEND = f"redis://{REDIS_HOST}:{REDIS_PORT}/{REDIS_RESULTS_DB}"
+    CELERYD_LOG_LEVEL = "DEBUG"
+    CELERYD_PREFETCH_MULTIPLIER = 1
+    CELERY_ACKS_LATE = False
+    CELERYBEAT_SCHEDULE = {
+        "reports.scheduler": {
+            "task": "reports.scheduler",
+            "schedule": crontab(minute="*", hour="*"),
+        },
+        "reports.prune_log": {
+            "task": "reports.prune_log",
+            "schedule": crontab(minute=10, hour=0),
+        },
+    }
+
+
+CELERY_CONFIG = CeleryConfig
+
+FEATURE_FLAGS = {"ALERT_REPORTS": True}
+ALERT_REPORTS_NOTIFICATION_DRY_RUN = True
+WEBDRIVER_BASEURL = "http://superset:8088/"
+# The base URL for the email report hyperlinks.
+WEBDRIVER_BASEURL_USER_FRIENDLY = WEBDRIVER_BASEURL
+
+SQLLAB_CTAS_NO_LIMIT = True
+
+#
+# Optionally import superset_config_docker.py (which will have been included on
+# the PYTHONPATH) in order to allow for local settings to be overridden
+#
+try:
+    import superset_config_docker
+    from superset_config_docker import *  # noqa
+
+    print(f"Loaded your Docker configuration at " f"[{superset_config_docker.__file__}]")
+except ImportError:
+    print("Using default Docker config...")

--- a/tutorsuperset/templates/superset/apps/pythonpath/superset_config_docker.py
+++ b/tutorsuperset/templates/superset/apps/pythonpath/superset_config_docker.py
@@ -1,4 +1,5 @@
 import os
+from urllib.parse import urljoin
 from flask_appbuilder.security.manager import AUTH_OAUTH
 
 # Application secret key
@@ -14,10 +15,11 @@ OPENEDX_DATABASE = {
     'password': os.environ["OPENEDX_MYSQL_PASSWORD"],
 }
 
+OPENEDX_LMS_ROOT_URL = os.environ["OPENEDX_LMS_ROOT_URL"]
 OPENEDX_API_URLS = {
-    "get_username": os.environ["OPENEDX_USERNAME_URL"],
-    "get_profile": os.environ["OPENEDX_USER_PROFILE_URL"],
-    "get_courses": os.environ["OPENEDX_COURSES_LIST_URL"],
+    "get_username": urljoin(OPENEDX_LMS_ROOT_URL, os.environ["OPENEDX_USERNAME_PATH"]),
+    "get_profile": urljoin(OPENEDX_LMS_ROOT_URL, os.environ["OPENEDX_USER_PROFILE_PATH"]),
+    "get_courses": urljoin(OPENEDX_LMS_ROOT_URL, os.environ["OPENEDX_COURSES_LIST_PATH"]),
 }
 
 # Set the authentication type to OAuth
@@ -40,9 +42,9 @@ OAUTH_PROVIDERS = [
             'access_token_headers':{    # Additional headers for calls to access_token_url
                 'Authorization': 'Basic Base64EncodedClientIdAndSecret'
             },
-            'api_base_url': os.environ["OAUTH2_BASE_URL"],
-            'access_token_url': os.environ["OAUTH2_ACCESS_TOKEN_URL"],
-            'authorize_url': os.environ["OAUTH2_AUTHORIZE_URL"],
+            'api_base_url': OPENEDX_LMS_ROOT_URL,
+            'access_token_url': urljoin(OPENEDX_LMS_ROOT_URL, os.environ["OAUTH2_ACCESS_TOKEN_PATH"]),
+            'authorize_url': urljoin(OPENEDX_LMS_ROOT_URL, os.environ["OAUTH2_AUTHORIZE_PATH"]),
         }
     }
 ]

--- a/tutorsuperset/templates/superset/apps/pythonpath/superset_config_docker.py
+++ b/tutorsuperset/templates/superset/apps/pythonpath/superset_config_docker.py
@@ -1,0 +1,82 @@
+import os
+from flask_appbuilder.security.manager import AUTH_OAUTH
+
+# Application secret key
+
+SECRET_KEY = os.environ["SECRET_KEY"]
+
+# Credentials for connecting to the Open edX MySQL database
+OPENEDX_DATABASE = {
+    'host': os.environ["OPENEDX_MYSQL_HOST"],
+    'port': int(os.environ["OPENEDX_MYSQL_PORT"]),
+    'database': os.environ["OPENEDX_MYSQL_DATABASE"],
+    'user': os.environ["OPENEDX_MYSQL_USERNAME"],
+    'password': os.environ["OPENEDX_MYSQL_PASSWORD"],
+}
+
+OPENEDX_API_URLS = {
+    "get_username": os.environ["OPENEDX_USERNAME_URL"],
+    "get_profile": os.environ["OPENEDX_USER_PROFILE_URL"],
+    "get_courses": os.environ["OPENEDX_COURSES_LIST_URL"],
+}
+
+# Set the authentication type to OAuth
+AUTH_TYPE = AUTH_OAUTH
+
+OAUTH_PROVIDERS = [
+    {   'name':'openedxsso',
+        'token_key':'access_token', # Name of the token in the response of access_token_url
+        'icon':'fa-address-card',   # Icon for the provider
+        'remote_app': {
+            'client_id': os.environ["OAUTH2_CLIENT_ID"],
+            'client_secret': os.environ["OAUTH2_CLIENT_SECRET"],
+            'client_kwargs':{
+                'scope': 'read'               # Scope for the Authorization
+            },
+            'access_token_method':'POST',    # HTTP Method to call access_token_url
+            'access_token_params':{        # Additional parameters for calls to access_token_url
+                'client_id': os.environ["OAUTH2_CLIENT_ID"],
+            },
+            'access_token_headers':{    # Additional headers for calls to access_token_url
+                'Authorization': 'Basic Base64EncodedClientIdAndSecret'
+            },
+            'api_base_url': os.environ["OAUTH2_BASE_URL"],
+            'access_token_url': os.environ["OAUTH2_ACCESS_TOKEN_URL"],
+            'authorize_url': os.environ["OAUTH2_AUTHORIZE_URL"],
+        }
+    }
+]
+
+# Will allow user self registration, allowing to create Flask users from Authorized User
+AUTH_USER_REGISTRATION = True
+
+# The default user self registration role
+AUTH_USER_REGISTRATION_ROLE = "Gamma"
+
+# Should we replace ALL the user's roles each login, or only on registration?
+AUTH_ROLES_SYNC_AT_LOGIN = True
+
+# map from the values of `userinfo["role_keys"]` to a list of Superset roles
+# cf https://superset.apache.org/docs/security/#roles
+AUTH_ROLES_MAPPING = {
+    "admin": ["Admin"],      # Superusers
+    "alpha": ["Alpha"],      # Global staff
+    "gamma": ["Gamma"],      # Course staff
+    "openedx": ["Open edX"], # Open edX datastore, manually created
+    "public": ["Public"],    # AKA anonymous users
+}
+
+from openedx_sso_security_manager import OpenEdxSsoSecurityManager, can_view_courses
+CUSTOM_SECURITY_MANAGER = OpenEdxSsoSecurityManager
+
+
+# Enable use of variables in datasets/queries
+FEATURE_FLAGS = {
+    "ALERT_REPORTS": True,
+    "ENABLE_TEMPLATE_PROCESSING": True,
+}
+
+# Add this custom template processor which returns the list of courses the current user can access
+JINJA_CONTEXT_ADDONS = {
+    'can_view_courses': can_view_courses
+}

--- a/tutorsuperset/templates/superset/jobs/init/init-mysql.sh
+++ b/tutorsuperset/templates/superset/jobs/init/init-mysql.sh
@@ -1,0 +1,21 @@
+echo "Initialising MySQL..."
+mysql_connection_max_attempts=10
+mysql_connection_attempt=0
+until mysql -u {{ MYSQL_ROOT_USERNAME }} --password="{{ MYSQL_ROOT_PASSWORD }}" --host "{{ MYSQL_HOST }}" --port {{ MYSQL_PORT }} -e 'exit'
+do
+    mysql_connection_attempt=$(expr $mysql_connection_attempt + 1)
+    echo "    [$mysql_connection_attempt/$mysql_connection_max_attempts] Waiting for MySQL service (this may take a while)..."
+    if [ $mysql_connection_attempt -eq $mysql_connection_max_attempts ]
+    then
+      echo "MySQL initialisation error" 1>&2
+      exit 1
+    fi
+    sleep 10
+done
+echo "MySQL is up and running"
+
+# edx-platform database
+mysql -u {{ MYSQL_ROOT_USERNAME }} --password="{{ MYSQL_ROOT_PASSWORD }}" --host "{{ MYSQL_HOST }}" --port {{ MYSQL_PORT }} -e "CREATE DATABASE IF NOT EXISTS {{ SUPERSET_DB_NAME }};"
+mysql -u {{ MYSQL_ROOT_USERNAME }} --password="{{ MYSQL_ROOT_PASSWORD }}" --host "{{ MYSQL_HOST }}" --port {{ MYSQL_PORT }} -e "CREATE USER IF NOT EXISTS '{{ SUPERSET_DB_USERNAME }}';"
+mysql -u {{ MYSQL_ROOT_USERNAME }} --password="{{ MYSQL_ROOT_PASSWORD }}" --host "{{ MYSQL_HOST }}" --port {{ MYSQL_PORT }} -e "ALTER USER '{{ SUPERSET_DB_USERNAME }}'@'%' IDENTIFIED BY '{{ SUPERSET_DB_PASSWORD }}';"
+mysql -u {{ MYSQL_ROOT_USERNAME }} --password="{{ MYSQL_ROOT_PASSWORD }}" --host "{{ MYSQL_HOST }}" --port {{ MYSQL_PORT }} -e "GRANT ALL ON {{ SUPERSET_DB_NAME }}.* TO '{{ SUPERSET_DB_USERNAME }}'@'%';"

--- a/tutorsuperset/templates/superset/jobs/init/init-openedx.sh
+++ b/tutorsuperset/templates/superset/jobs/init/init-openedx.sh
@@ -1,0 +1,9 @@
+# Create a DOT applicaton so Superset can use Open edX authenticatioon
+./manage.py lms manage_user superset superset@apache
+./manage.py lms create_dot_application \
+    --grant-type authorization-code \
+    --redirect-uris "{% if ENABLE_HTTPS %}https{% else %}http{% endif %}://{{ SUPERSET_HOST }}:{{ SUPERSET_PORT }}/oauth-authorized/openedxsso" \
+    --client-id {{ SUPERSET_OAUTH2_CLIENT_ID }} \
+    --client-secret {{ SUPERSET_OAUTH2_CLIENT_SECRET }} \
+    --scopes user_id \
+    superset-sso superset

--- a/tutorsuperset/templates/superset/jobs/init/init-superset.sh
+++ b/tutorsuperset/templates/superset/jobs/init/init-superset.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# Modified from original:
+#
+# https://github.com/apache/superset/blob/969c963/docker/docker-init.sh
+
+set -e
+
+#
+# Always install local overrides first
+#
+/usr/bin/env bash /app/docker/docker-bootstrap.sh
+
+STEP_CNT=4
+
+echo_step() {
+cat <<EOF
+
+######################################################################
+
+
+Init Step ${1}/${STEP_CNT} [${2}] -- ${3}
+
+
+######################################################################
+
+EOF
+}
+# Initialize the database
+echo_step "1" "Starting" "Applying DB migrations"
+superset db upgrade
+echo_step "1" "Complete" "Applying DB migrations"
+
+# If Cypress run – overwrite the password for admin and export env variables
+if [ "$CYPRESS_CONFIG" == "true" ]; then
+    ADMIN_USERNAME="admin"
+    ADMIN_PASSWORD="general"
+    export SUPERSET_CONFIG=tests.integration_tests.superset_test_config
+    export SUPERSET_TESTENV=true
+    export SUPERSET__SQLALCHEMY_DATABASE_URI=postgresql+psycopg2://superset:superset@db:5432/superset
+fi
+
+# Create an admin user
+echo_step "2" "Starting" "Setting up admin user ( $ADMIN_USERNAME / $ADMIN_PASSWORD )"
+superset fab create-admin \
+              --username $ADMIN_USERNAME \
+              --firstname Superset \
+              --lastname Admin \
+              --email admin@superset.com \
+              --password $ADMIN_PASSWORD
+echo_step "2" "Complete" "Setting up admin user"
+
+# Create default roles and permissions
+echo_step "3" "Starting" "Setting up roles and perms"
+superset init
+echo_step "3" "Complete" "Setting up roles and perms"
+
+if [ "$SUPERSET_LOAD_EXAMPLES" ]; then
+    # Load some data to play with
+    echo_step "4" "Starting" "Loading examples"
+
+    # If Cypress run which consumes superset_test_config – load required data for tests
+    if [ "$CYPRESS_CONFIG" == "true" ]; then
+        superset load_test_users
+        superset load_examples --load-test-data
+    else
+        superset load_examples
+    fi
+    echo_step "4" "Complete" "Loading examples"
+else
+    echo_step "4" "Skipped" "Loading examples"
+fi

--- a/tutorsuperset/templates/superset/jobs/init/init-superset.sh
+++ b/tutorsuperset/templates/superset/jobs/init/init-superset.sh
@@ -27,7 +27,7 @@ set -e
 #
 /usr/bin/env bash /app/docker/docker-bootstrap.sh
 
-STEP_CNT=4
+STEP_CNT=2
 
 echo_step() {
 cat <<EOF
@@ -47,42 +47,7 @@ echo_step "1" "Starting" "Applying DB migrations"
 superset db upgrade
 echo_step "1" "Complete" "Applying DB migrations"
 
-# If Cypress run – overwrite the password for admin and export env variables
-if [ "$CYPRESS_CONFIG" == "true" ]; then
-    ADMIN_USERNAME="admin"
-    ADMIN_PASSWORD="general"
-    export SUPERSET_CONFIG=tests.integration_tests.superset_test_config
-    export SUPERSET_TESTENV=true
-    export SUPERSET__SQLALCHEMY_DATABASE_URI=postgresql+psycopg2://superset:superset@db:5432/superset
-fi
-
-# Create an admin user
-echo_step "2" "Starting" "Setting up admin user ( $ADMIN_USERNAME / $ADMIN_PASSWORD )"
-superset fab create-admin \
-              --username $ADMIN_USERNAME \
-              --firstname Superset \
-              --lastname Admin \
-              --email admin@superset.com \
-              --password $ADMIN_PASSWORD
-echo_step "2" "Complete" "Setting up admin user"
-
 # Create default roles and permissions
-echo_step "3" "Starting" "Setting up roles and perms"
+echo_step "2" "Starting" "Setting up roles and perms"
 superset init
-echo_step "3" "Complete" "Setting up roles and perms"
-
-if [ "$SUPERSET_LOAD_EXAMPLES" ]; then
-    # Load some data to play with
-    echo_step "4" "Starting" "Loading examples"
-
-    # If Cypress run which consumes superset_test_config – load required data for tests
-    if [ "$CYPRESS_CONFIG" == "true" ]; then
-        superset load_test_users
-        superset load_examples --load-test-data
-    else
-        superset load_examples
-    fi
-    echo_step "4" "Complete" "Loading examples"
-else
-    echo_step "4" "Skipped" "Loading examples"
-fi
+echo_step "2" "Complete" "Setting up roles and perms"


### PR DESCRIPTION
This plugin runs Superset in Tutor, with the following customizations:

* installs python packages to support mysql and OAuth2
* configures SSO from LMS to Superset
* adds custom oauth2 manager which uses LMS APIs and the mysql database to determine user permission levels.
* adds custom course permissions plugin for use with SQL queries.

**Testing instructions**

See updated [README.rst](https://github.com/open-craft/tutor-contrib-superset/tree/jill/install-superset#superset-plugin-for-tutor)

**Author Notes & Concerns**

1. Should we use the openedx redis instance instead of running our own here?
   A: Yes
2. Can/should we use the openedx mysql database for superset instead of running a separate postgres db?
    I tried this, but wasn't able to work out how to get superset's db migrations working.
3. I think this needs a follow-up PR, which updates [superset init script](https://github.com/open-craft/tutor-contrib-superset/blob/jill/install-superset/tutorsuperset/templates/superset/tasks/init-superset.sh) to use the [Superset API](https://superset.apache.org/docs/api) to [create the OpenedX dataset + chart](https://github.com/open-craft/superset/blob/jill/openedx-sso/README-openedx.md#connect-superset-to-the-open-edx-mysql-database), and  [set up roles and row-level security](https://github.com/open-craft/superset/blob/jill/openedx-sso/README-openedx.md#restrict-access-to-open-edx-enrollments-to-course-staff). But I think this can wait until we know exactly how we're going to use Superset with Open edX.